### PR TITLE
Have `ActionBar.addAction(Type)` Return Instance

### DIFF
--- a/GreenDroid/src/greendroid/widget/ActionBar.java
+++ b/GreenDroid/src/greendroid/widget/ActionBar.java
@@ -165,8 +165,10 @@ public class ActionBar extends LinearLayout {
         }
     }
 
-    public void addItem(ActionBarItem.Type actionBarItemType) {
-        addItem(ActionBarItem.createWithType(this, actionBarItemType));
+    public ActionBarItem addItem(ActionBarItem.Type actionBarItemType) {
+        ActionBarItem item = ActionBarItem.createWithType(this, actionBarItemType);
+        addItem(item);
+        return item;
     }
 
     public void addItem(ActionBarItem item) {


### PR DESCRIPTION
This will allow for the storing of handles to action bar items from the `onCreate` method. This does not change the helper method in `GDActivity` (since that is specified by an interface), only the direct `addItem` method in `ActionBar`.

E.g., I create a `Type.Refresh` item and want to instantly trigger the refreshing state while the activity content loads.

```
LoaderActionBarItem refresh = (LoaderActionBarItem)this.getActionBar().addItem(Type.Refresh);
refresh.setLoading(true);
```
