### PR TITLE
Settings type

### DIFF
--- a/GreenDroid/res/values/gd_strings.xml
+++ b/GreenDroid/res/values/gd_strings.xml
@@ -32,6 +32,7 @@
 	<string name="gd_edit">Edit</string>
 	<string name="gd_add">Add</string>
 	<string name="gd_star">Star</string>
+	<string name="gd_settings">Settings</string>
 	<string name="gd_sort_by_size">Sort by size</string>
 	<string name="gd_locate_myself">Locate myself</string>
 

--- a/GreenDroid/src/greendroid/widget/ActionBarItem.java
+++ b/GreenDroid/src/greendroid/widget/ActionBarItem.java
@@ -229,37 +229,49 @@ public abstract class ActionBarItem {
             	
             case Help:
             	drawableId = R.drawable.gd_action_bar_help;
-            	
+            	break;
+
             case Info:
             	drawableId = R.drawable.gd_action_bar_info;
-            	
+            	break;
+
             case Settings:
             	drawableId = R.drawable.gd_action_bar_settings;
-            	
+            	descriptionId = R.string.gd_settings;
+            	break;
+
             case List:
             	drawableId = R.drawable.gd_action_bar_list;
+            	break;
             	
             case Trashcan:
             	drawableId = R.drawable.gd_action_bar_trashcan;
-            	
+            	break;
+
             case Eye:
             	drawableId = R.drawable.gd_action_bar_eye;
-            	
+            	break;
+
             case AllFriends:
             	drawableId = R.drawable.gd_action_bar_all_friends;
-            	
+            	break;
+
             case Group:
             	drawableId = R.drawable.gd_action_bar_group;
-            	
+            	break;
+
             case Gallery:
             	drawableId = R.drawable.gd_action_bar_gallery;
-            	
+            	break;
+
             case Slideshow:
             	drawableId = R.drawable.gd_action_bar_slideshow;
-            	
+            	break;
+
             case Mail:
             	drawableId = R.drawable.gd_action_bar_mail;
-            	
+            	break;
+
             default:
                 // Do nothing but return null
                 return null;


### PR DESCRIPTION
addActionBarItem(Type.Settings); doesn't work because there is no break in the switch case inside createWithType. This cause to end up in the default case which returns null.

I have added break; to other items but I didn't provide a descriptionId.
