### PR TITLE
Light themes & Turkish Translation

### DIFF
--- a/GreenDroid/res/values-tr/gd_strings.xml
+++ b/GreenDroid/res/values-tr/gd_strings.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright (C) 2010 Cyril Mottier (http://www.cyrilmottier.com)
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<resources>
+
+	<string name="gd_go_home">Ana Sayfa</string>
+	<string name="gd_search">Ara</string>
+	<string name="gd_talk">Konuş</string>
+	<string name="gd_compose">Yeni</string>
+	<string name="gd_export">Dışarı Aktar</string>
+	<string name="gd_share">Paylaş</string>
+	<string name="gd_refresh">Yenile</string>
+	<string name="gd_take_photo">Fotoğraf Makinasından</string>
+	<string name="gd_pick_photo">Galeriden</string>
+	<string name="gd_locate">Yerini belirle</string>
+	<string name="gd_edit">Düzenle</string>
+	<string name="gd_add">Ekle</string>
+	<string name="gd_star">Yıldız</string>
+	<string name="gd_sort_by_size">Boyuta göre sırala</string>
+	<string name="gd_locate_myself">Konumumu bul</string>
+	<string name="gd_compass">Pusula</string>
+	<string name="gd_help">Yardım</string>
+	<string name="gd_info">Bilgi</string>
+	<string name="gd_settings">Ayarlar</string>
+	<string name="gd_list">Liste</string>
+	<string name="gd_trashcan">Sil</string>
+	<string name="gd_eye">Bak</string>
+	<string name="gd_all_friends">Tüm arkadaşlar</string>
+	<string name="gd_group">Grup</string>
+	<string name="gd_gallery">Galeri</string>
+	<string name="gd_slideshow">Slide gösterisi</string>
+	<string name="gd_mail">Posta</string>
+
+</resources>

--- a/GreenDroid/res/values/gd_themes.xml
+++ b/GreenDroid/res/values/gd_themes.xml
@@ -110,4 +110,93 @@
 	
 	</style>
 	
+	<style name="Theme.GreenDroid.Light" parent="@android:style/Theme.Light">
+	
+		<item name="gdTextAppearance">@style/TextAppearance</item>
+		<item name="gdTextAppearanceLarge">@style/TextAppearance.Large</item>
+		<item name="gdTextAppearanceMedium">@style/TextAppearance.Medium</item>
+		<item name="gdTextAppearanceSmall">@style/TextAppearance.Small</item>
+		<item name="gdTextAppearanceSeparator">@style/TextAppearance.Separator</item>
+		
+		<item name="gdDrawableWidth">@dimen/gd_drawable_width</item>
+		<item name="gdDrawableHeight">@dimen/gd_drawable_height</item>
+		<item name="gdDrawableMargin">@dimen/gd_drawable_margin</item>
+		
+		<item name="gdProgressBarWidth">@dimen/gd_progress_bar_width</item>
+		<item name="gdProgressBarHeight">@dimen/gd_progress_bar_height</item>
+		<item name="gdProgressBarMargin">@dimen/gd_progress_bar_margin</item>
+		
+		<item name="gdItemViewPreferredHeight">@dimen/gd_item_view_height</item>
+		<item name="gdItemViewPreferredHalfHeight">@dimen/gd_item_view_half_height</item>
+		<item name="gdItemViewPreferredPaddingLeft">@dimen/gd_item_view_padding_left</item>
+		<item name="gdSeparatorItemViewPreferredHeight">@dimen/gd_separator_item_view_height</item>
+		
+		<item name="gdTextItemViewStyle">@style/GreenDroid.Widget.ItemView.TextItemView</item>
+		<item name="gdLongTextItemViewStyle">@style/GreenDroid.Widget.ItemView.LongTextItemView</item>
+		<item name="gdDescriptionItemViewStyle">@style/GreenDroid.Widget.ItemView.DescriptionItemView</item>
+		
+		<item name="gdSeparatorItemViewStyle">@style/GreenDroid.Widget.ItemView.SeparatorItemView</item>
+		
+		<item name="gdProgressItemViewStyle">@style/GreenDroid.Widget.ItemView.ProgressItemView</item>
+		<item name="gdProgressItemViewStyleText">@style/GreenDroid.Widget.ItemView.ProgressItemView.Text</item>
+		<item name="gdProgressItemViewStyleProgressBar">@style/GreenDroid.Widget.ItemView.ProgressItemView.ProgressBar</item>
+
+		<item name="gdDrawableItemViewStyle">@style/GreenDroid.Widget.ItemView.DrawableItemView</item>
+		<item name="gdDrawableItemViewStyleText">@style/GreenDroid.Widget.ItemView.DrawableItemView.Text</item>
+		<item name="gdDrawableItemViewStyleDrawable">@style/GreenDroid.Widget.ItemView.DrawableItemView.Drawable</item>
+		
+		<item name="gdSubtitleItemViewStyle">@style/GreenDroid.Widget.ItemView.SubtitleItemView</item>
+		<item name="gdSubtitleItemViewStyleText">@style/GreenDroid.Widget.ItemView.SubtitleItemView.Text</item>
+		<item name="gdSubtitleItemViewStyleSubtitle">@style/GreenDroid.Widget.ItemView.SubtitleItemView.Subtitle</item>
+		
+		<item name="gdSubtextItemViewStyle">@style/GreenDroid.Widget.ItemView.SubtextItemView</item>
+		<item name="gdSubtextItemViewStyleText">@style/GreenDroid.Widget.ItemView.SubtextItemView.Text</item>
+		<item name="gdSubtextItemViewStyleSubtext">@style/GreenDroid.Widget.ItemView.SubtextItemView.Subtext</item>
+		
+		<item name="gdThumbnailItemViewStyle">@style/GreenDroid.Widget.ItemView.ThumbnailItemView</item>
+		<item name="gdThumbnailItemViewStyleText">@style/GreenDroid.Widget.ItemView.ThumbnailItemView.Text</item>
+		<item name="gdThumbnailItemViewStyleSubtitle">@style/GreenDroid.Widget.ItemView.ThumbnailItemView.Subtitle</item>
+		<item name="gdThumbnailItemViewStyleThumbnail">@style/GreenDroid.Widget.ItemView.ThumbnailItemView.Thumbnail</item>
+		
+		<item name="gdSegmentTextColor">@android:color/black</item>
+		<item name="gdSegmentTextSize">14sp</item>
+		<item name="gdSegmentBackground">@drawable/gd_segment_label</item>
+		<item name="gdSegmentCheckmark">@drawable/gd_segment_checkmark</item>
+		<item name="gdSegmentedBarStyle">@style/GreenDroid.Widget.SegmentedBar</item>
+		<item name="gdSegmentedHostStyle">@style/GreenDroid.Widget.SegmentedHost</item>
+		
+		<item name="gdActionBarTitleColor">@android:color/white</item>
+		<item name="gdActionBarBackground">@color/gd_action_bar_tint</item>
+		<item name="gdActionBarItemBackground">@drawable/gd_action_bar_item</item>
+		<item name="gdActionBarDividerDrawable">@color/gd_action_bar_divider_tint</item>
+		<item name="gdActionBarDividerWidth">1px</item>
+		<item name="gdActionBarApplicationDrawable">@null</item>
+		<item name="gdActionBarHomeDrawable">@null</item>
+		<item name="gdActionBarItemColorNormal">@android:color/white</item>
+		<item name="gdActionBarItemColorAlt">@android:color/black</item>
+
+		<item name="gdActionBarStyle">@style/GreenDroid.Widget.ActionBar</item>
+		<item name="gdActionBarTitleStyle">@style/GreenDroid.Widget.ActionBar.Title</item>
+		<item name="gdActionBarItemStyle">@style/GreenDroid.Widget.ActionBar.Item</item>
+
+		<item name="gdTabIndicatorHeight">38dp</item>
+		<item name="gdTabIndicatorTextAppearance">@style/TextAppearance.TabIndicator</item>
+		<item name="gdTabIndicatorBackground">@drawable/gd_tab_indicator</item>
+		
+		<item name="gdTabIndicatorStyle">@style/GreenDroid.Widget.TabIndicator</item>
+		
+		<item name="gdQuickActionBarStyle">@style/GreenDroid.Widget.QuickAction.Bar</item>
+		<item name="gdQuickActionBarItemStyle">@style/GreenDroid.Widget.QuickAction.Bar.Item</item>
+		<item name="gdQuickActionGridStyle">@style/GreenDroid.Widget.QuickAction.Grid</item>
+		<item name="gdQuickActionGridItemStyle">@style/GreenDroid.Widget.QuickAction.Grid.Item</item>
+		
+		<item name="gdPageIndicatorStyle">@style/GreenDroid.Widget.PageIndicator</item>
+	</style>
+	
+	<style name="Theme.GreenDroid.NoTitleBar.Light" parent="@style/Theme.GreenDroid.Light">
+	
+		<item name="android:windowContentOverlay">@null</item>
+		<item name="android:windowNoTitle">true</item>
+	
+	</style>
 </resources>


### PR DESCRIPTION
Instead of using standard dark theme, added two alternative theme derived from Light theme. These can be used calling Theme.GreenDroid.Light  & Theme.GreenDroid.NoTitleBar.Light  

We use it in our app "itü sözlük": https://market.android.com/details?id=com.itusozluk.android

Also, I made a Turkish translation
