### PR TITLE
Fixed bug : was crashing when removing an item from a list and adding another one of a different type

### DIFF
--- a/GreenDroid/src/greendroid/widget/ItemAdapter.java
+++ b/GreenDroid/src/greendroid/widget/ItemAdapter.java
@@ -76,9 +76,9 @@ public class ItemAdapter extends BaseAdapter {
         int type;
     }
 
-    private List<Item> mItems;
-    private HashMap<Class<? extends Item>, TypeInfo> mTypes;
-    private Context mContext;
+    private final List<Item> mItems;
+    private final HashMap<Class<? extends Item>, TypeInfo> mTypes;
+    private final Context mContext;
 
     private boolean mNotifyOnChange;
     private int mMaxViewTypeCount;
@@ -403,15 +403,18 @@ public class ItemAdapter extends BaseAdapter {
         return new ItemAdapter(context, items);
     }
 
-    public int getCount() {
+    @Override
+	public int getCount() {
         return mItems.size();
     }
 
-    public Object getItem(int position) {
+    @Override
+	public Object getItem(int position) {
         return mItems.get(position);
     }
 
-    public long getItemId(int position) {
+    @Override
+	public long getItemId(int position) {
         return position;
     }
 
@@ -430,12 +433,13 @@ public class ItemAdapter extends BaseAdapter {
         return mMaxViewTypeCount;
     }
 
-    public View getView(int position, View convertView, ViewGroup parent) {
+    @Override
+	public View getView(int position, View convertView, ViewGroup parent) {
 
         final Item item = (Item) getItem(position);
         ItemView cell = (ItemView) convertView;
 
-        if (cell == null) {
+        if (cell == null || cell.getItemClass() != item.getClass()) {
             cell = item.newView(mContext, null);
             cell.prepareItemView();
         }

--- a/GreenDroid/src/greendroid/widget/itemview/DescriptionItemView.java
+++ b/GreenDroid/src/greendroid/widget/itemview/DescriptionItemView.java
@@ -41,11 +41,17 @@ public class DescriptionItemView extends TextView implements ItemView {
         super(context, attrs, defStyle);
     }
 
-    public void prepareItemView() {
+    @Override
+	public void prepareItemView() {
     }
 
     public void setObject(Item item) {
         setText(((TextItem) item).text);
     }
+
+	@Override
+	public Class<? extends Item> getItemClass() {
+		return TextItem.class;
+	}
 
 }

--- a/GreenDroid/src/greendroid/widget/itemview/DrawableItemView.java
+++ b/GreenDroid/src/greendroid/widget/itemview/DrawableItemView.java
@@ -17,6 +17,8 @@ package greendroid.widget.itemview;
 
 import greendroid.widget.item.DrawableItem;
 import greendroid.widget.item.Item;
+import greendroid.widget.item.TextItem;
+
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
@@ -44,12 +46,14 @@ public class DrawableItemView extends LinearLayout implements ItemView {
         super(context, attrs);
     }
 
-    public void prepareItemView() {
+    @Override
+	public void prepareItemView() {
         mTextView = (TextView) findViewById(R.id.gd_text);
         mImageView = (ImageView) findViewById(R.id.gd_drawable);
     }
 
-    public void setObject(Item object) {
+    @Override
+	public void setObject(Item object) {
         final DrawableItem item = (DrawableItem) object;
         mTextView.setText(item.text);
 
@@ -61,5 +65,10 @@ public class DrawableItemView extends LinearLayout implements ItemView {
             mImageView.setImageResource(drawableId);
         }
     }
+
+	@Override
+	public Class<? extends Item> getItemClass() {
+		return DrawableItem.class;
+	}
 
 }

--- a/GreenDroid/src/greendroid/widget/itemview/ItemView.java
+++ b/GreenDroid/src/greendroid/widget/itemview/ItemView.java
@@ -48,4 +48,6 @@ public interface ItemView {
      */
     void setObject(Item item);
 
+	Class<? extends Item> getItemClass();
+
 }

--- a/GreenDroid/src/greendroid/widget/itemview/LongTextItemView.java
+++ b/GreenDroid/src/greendroid/widget/itemview/LongTextItemView.java
@@ -15,6 +15,7 @@
  */
 package greendroid.widget.itemview;
 
+import greendroid.widget.item.DrawableItem;
 import greendroid.widget.item.Item;
 import greendroid.widget.item.LongTextItem;
 import android.content.Context;
@@ -40,11 +41,18 @@ public class LongTextItemView extends TextView implements ItemView {
         super(context, attrs, defStyle);
     }
 
-    public void prepareItemView() {
+    @Override
+	public void prepareItemView() {
     }
 
-    public void setObject(Item item) {
+    @Override
+	public void setObject(Item item) {
         setText(((LongTextItem) item).text);
     }
+
+	@Override
+	public Class<? extends Item> getItemClass() {
+		return LongTextItem.class;
+	}
 
 }

--- a/GreenDroid/src/greendroid/widget/itemview/ProgressItemView.java
+++ b/GreenDroid/src/greendroid/widget/itemview/ProgressItemView.java
@@ -16,6 +16,7 @@
 package greendroid.widget.itemview;
 
 import greendroid.widget.item.Item;
+import greendroid.widget.item.LongTextItem;
 import greendroid.widget.item.ProgressItem;
 import android.content.Context;
 import android.util.AttributeSet;
@@ -48,15 +49,22 @@ public class ProgressItemView extends FrameLayout implements ItemView {
         super(context, attrs, defStyle);
     }
 
-    public void prepareItemView() {
+    @Override
+	public void prepareItemView() {
         mProgressBar = (ProgressBar) findViewById(R.id.gd_progress_bar);
         mTextView = (TextView) findViewById(R.id.gd_text);
     }
 
-    public void setObject(Item object) {
+    @Override
+	public void setObject(Item object) {
         final ProgressItem item = (ProgressItem) object;
         mProgressBar.setVisibility(item.isInProgress ? View.VISIBLE : View.GONE);
         mTextView.setText(item.text);
     }
+
+	@Override
+	public Class<? extends Item> getItemClass() {
+		return ProgressItem.class;
+	}
 
 }

--- a/GreenDroid/src/greendroid/widget/itemview/SeparatorItemView.java
+++ b/GreenDroid/src/greendroid/widget/itemview/SeparatorItemView.java
@@ -16,6 +16,7 @@
 package greendroid.widget.itemview;
 
 import greendroid.widget.item.Item;
+import greendroid.widget.item.ProgressItem;
 import greendroid.widget.item.SeparatorItem;
 import greendroid.widget.item.TextItem;
 import android.content.Context;
@@ -41,12 +42,19 @@ public class SeparatorItemView extends TextView implements ItemView {
         super(context, attrs, defStyle);
     }
 
-    public void prepareItemView() {
+    @Override
+	public void prepareItemView() {
     }
 
-    public void setObject(Item object) {
+    @Override
+	public void setObject(Item object) {
         final TextItem item = (TextItem) object;
         setText(item.text);
     }
+
+	@Override
+	public Class<? extends Item> getItemClass() {
+		return TextItem.class;
+	}
 
 }

--- a/GreenDroid/src/greendroid/widget/itemview/SubtextItemView.java
+++ b/GreenDroid/src/greendroid/widget/itemview/SubtextItemView.java
@@ -17,6 +17,8 @@ package greendroid.widget.itemview;
 
 import greendroid.widget.item.Item;
 import greendroid.widget.item.SubtextItem;
+import greendroid.widget.item.TextItem;
+
 import android.content.Context;
 import android.util.AttributeSet;
 import android.widget.LinearLayout;
@@ -42,15 +44,22 @@ public class SubtextItemView extends LinearLayout implements ItemView {
         super(context, attrs);
     }
 
-    public void prepareItemView() {
+    @Override
+	public void prepareItemView() {
         mTextView = (TextView) findViewById(R.id.gd_text);
         mSubtextView = (TextView) findViewById(R.id.gd_subtext);
     }
 
-    public void setObject(Item object) {
+    @Override
+	public void setObject(Item object) {
         final SubtextItem item = (SubtextItem) object;
         mTextView.setText(item.text);
         mSubtextView.setText(item.subtext);
     }
+
+	@Override
+	public Class<? extends Item> getItemClass() {
+		return SubtextItem.class;
+	}
 
 }

--- a/GreenDroid/src/greendroid/widget/itemview/SubtitleItemView.java
+++ b/GreenDroid/src/greendroid/widget/itemview/SubtitleItemView.java
@@ -16,6 +16,7 @@
 package greendroid.widget.itemview;
 
 import greendroid.widget.item.Item;
+import greendroid.widget.item.SubtextItem;
 import greendroid.widget.item.SubtitleItem;
 import android.content.Context;
 import android.util.AttributeSet;
@@ -42,15 +43,22 @@ public class SubtitleItemView extends LinearLayout implements ItemView {
         super(context, attrs);
     }
 
-    public void prepareItemView() {
+    @Override
+	public void prepareItemView() {
         mTextView = (TextView) findViewById(R.id.gd_text);
         mSubtitleView = (TextView) findViewById(R.id.gd_subtitle);
     }
 
-    public void setObject(Item object) {
+    @Override
+	public void setObject(Item object) {
         final SubtitleItem item = (SubtitleItem) object;
         mTextView.setText(item.text);
         mSubtitleView.setText(item.subtitle);
     }
+
+	@Override
+	public Class<? extends Item> getItemClass() {
+		return SubtitleItem.class;
+	}
 
 }

--- a/GreenDroid/src/greendroid/widget/itemview/TextItemView.java
+++ b/GreenDroid/src/greendroid/widget/itemview/TextItemView.java
@@ -16,6 +16,7 @@
 package greendroid.widget.itemview;
 
 import greendroid.widget.item.Item;
+import greendroid.widget.item.SubtitleItem;
 import greendroid.widget.item.TextItem;
 import android.content.Context;
 import android.util.AttributeSet;
@@ -40,11 +41,18 @@ public class TextItemView extends TextView implements ItemView {
         super(context, attrs, defStyle);
     }
 
-    public void prepareItemView() {
+    @Override
+	public void prepareItemView() {
     }
 
-    public void setObject(Item object) {
+    @Override
+	public void setObject(Item object) {
         setText(((TextItem) object).text);
     }
+
+	@Override
+	public Class<? extends Item> getItemClass() {
+		return TextItem.class;
+	}
 
 }

--- a/GreenDroid/src/greendroid/widget/itemview/ThumbnailItemView.java
+++ b/GreenDroid/src/greendroid/widget/itemview/ThumbnailItemView.java
@@ -17,6 +17,7 @@ package greendroid.widget.itemview;
 
 import greendroid.widget.AsyncImageView;
 import greendroid.widget.item.Item;
+import greendroid.widget.item.TextItem;
 import greendroid.widget.item.ThumbnailItem;
 import android.content.Context;
 import android.util.AttributeSet;
@@ -48,17 +49,24 @@ public class ThumbnailItemView extends RelativeLayout implements ItemView {
         super(context, attrs, defStyle);
     }
 
-    public void prepareItemView() {
+    @Override
+	public void prepareItemView() {
         mTextView = (TextView) findViewById(R.id.gd_text);
         mSubtitleView = (TextView) findViewById(R.id.gd_subtitle);
         mThumbnailView = (AsyncImageView) findViewById(R.id.gd_thumbnail);
     }
 
-    public void setObject(Item object) {
+    @Override
+	public void setObject(Item object) {
         final ThumbnailItem item = (ThumbnailItem) object;
         mTextView.setText(item.text);
         mSubtitleView.setText(item.subtitle);
         mThumbnailView.setDefaultImageResource(item.drawableId);
         mThumbnailView.setUrl(item.drawableURL);
     }
+
+	@Override
+	public Class<? extends Item> getItemClass() {
+		return ThumbnailItem.class;
+	}
 }


### PR DESCRIPTION
When removing then adding an Item, if the item added was of a different type than the previous one (for exemple replacing a TextItem with a ProgressItem), ItemAdapter.getView() would crash when trying to reuse the convertView
