### PR TITLE
Allow more flexibility in ThumbnailItemView's styling

### DIFF
--- a/GreenDroid/res/layout/gd_thumbnail_item_view.xml
+++ b/GreenDroid/res/layout/gd_thumbnail_item_view.xml
@@ -26,10 +26,7 @@
 	
 	<greendroid.widget.AsyncImageView
 		style="?attr/gdThumbnailItemViewStyleThumbnail"
-		android:id="@+id/gd_thumbnail"
-		android:layout_height="?attr/gdItemViewPreferredHeight"
-
-		android:scaleType="centerInside" />
+		android:id="@+id/gd_thumbnail" />
 
 	<TextView
 		style="?attr/gdThumbnailItemViewStyleText"

--- a/GreenDroid/res/values/gd_styles.xml
+++ b/GreenDroid/res/values/gd_styles.xml
@@ -132,6 +132,8 @@
 	</style>
 	<style name="GreenDroid.Widget.ItemView.ThumbnailItemView.Thumbnail">
 		<item name="android:layout_width">?attr/gdItemViewPreferredHeight</item>
+		<item name="android:layout_height">?attr/gdItemViewPreferredHeight</item>
+		<item name="android:scaleType">centerInside</item>
 		<item name="android:layout_marginRight">?attr/gdDrawableMargin</item>
 	</style>
 	


### PR DESCRIPTION
By moving the specification of layout_height and scaleType from the XML layout to the style definitions, it's possible for developers to override the defaults without modifying the base GreenDroid library.  One may simply override the styles in the application.

If I'm missing some compelling reason to leave these two attributes in the XML layout, please enlighten.
